### PR TITLE
Fix typos

### DIFF
--- a/production/documentation/entrances/slideshow/editing_styles.rb
+++ b/production/documentation/entrances/slideshow/editing_styles.rb
@@ -68,7 +68,7 @@ slide do
   
   sandbox_codeblock do
     code :text => "interesting_values {"
-    code :text => "  width 200"
+    code :text => "  width '100%'"
     code :text => "  horizontal_alignment :center"
     code :text => "  text_color 'dark_red'"
     code :text => "}"

--- a/production/documentation/entrances/slideshow/getting_started.rb
+++ b/production/documentation/entrances/slideshow/getting_started.rb
@@ -45,6 +45,20 @@ slide do
 end
 
 slide do
+  heading :text => "3a. Installing Limelight"
+  directions :text => "Next we need to install the RSpec gem.  The version of Limelight (0.5.5) uses an early version of RSpec.  In the command prompt you opened before type:"
+  codeblock do
+    code :text => "jruby -S gem install rspec -v 1.3.2"
+  end
+
+  directions :text => "On successful completion you should see a message like this:"
+  codeblock do
+    code :text => "Successfully installed rspec-1.3.2"
+    code :text => "1 gem installed"
+  end
+end
+
+slide do
   heading :text => "4. Your First Limelight App"
   directions :text => "Now that you've installed the gem you can create your first Limelight app.  At that same command prompt go to the directory of your choosing and type:"
   codeblock do

--- a/production/documentation/entrances/slideshow/getting_started.rb
+++ b/production/documentation/entrances/slideshow/getting_started.rb
@@ -46,7 +46,7 @@ end
 
 slide do
   heading :text => "3a. Installing Limelight"
-  directions :text => "Next we need to install the RSpec gem.  The version of Limelight (0.5.5) uses an early version of RSpec.  In the command prompt you opened before type:"
+  directions :text => "Next we need to install the RSpec gem.  This version of Limelight (0.5.5) uses an early version of RSpec.  In the command prompt you opened before type:"
   codeblock do
     code :text => "jruby -S gem install rspec -v 1.3.2"
   end
@@ -180,8 +180,8 @@ slide do
   directions :text => "Okay you've made the scene interactive - now let's make that a little more interesting.  Props can have styles, and we can go ahead and use those to make a prettier prop.  Open your props.rb file again and make it look like this:"
   codeblock do
     # ------------------------------------------------------------------------------------------------------------------
-    # This does not display properly in the slide.  Specifically, the commas separating the hash values do consistently
-    # appear.  Placing an apostrophe after each undisplayed comma causes it to be displayed properly.
+    # This does not display properly in the slide.  Specifically, the commas separating the hash values do not 
+    # appear consistently.  Placing an apostrophe after each undisplayed comma causes it to be displayed properly.
     # ------------------------------------------------------------------------------------------------------------------
     code :text => "root :text => \"Click Me!\",'" 
     code :text => "     :rounded_corner_radius => 10, :padding => 10,'"

--- a/production/documentation/entrances/slideshow/getting_started.rb
+++ b/production/documentation/entrances/slideshow/getting_started.rb
@@ -30,7 +30,7 @@ end
 
 slide do
   heading :text => "3. Installing Limelight"
-  directions :text => "Next we need toto install the Limelight gem.  In the command prompt you opened before type:"
+  directions :text => "Next we need to install the Limelight gem.  In the command prompt you opened before type:"
   codeblock do
     code :text => "jruby -S gem install limelight"
   end
@@ -60,7 +60,7 @@ end
 
 slide do
   heading :text => "4. Your First Limelight App"
-  directions :text => "Now that you've installed the gem you can create your first Limelight app.  At that same command prompt go to the directory of your choosing and type:"
+  directions :text => "Now that you've installed the gems you can create your first Limelight app.  At that same command prompt go to the directory of your choosing and type:"
   codeblock do
     code :text => "limelight create production hello_limelight"
   end
@@ -92,7 +92,7 @@ slide do
     code :text => "1 example, 0 failures"
   end
   
-  directions :text => "Good.  Now let's break them."
+  directions :text => "Good.  Now let's break the tests."
 end
 
 slide do
@@ -125,12 +125,12 @@ end
 
 slide do
   heading :text => "7. Text Attribute"
-  directions :text => "A failing test should never stay faling for very long.  Let's change that prop to match the expectation we set in the test.  Open the props.rb file in the default_scene directory.  There you'll see our prop:"
+  directions :text => "A failing test should never stay failing for very long.  Let's change that prop to match the expectation we set in the test.  Open the props.rb file in the default_scene directory.  There you'll see our prop:"
   codeblock do
     code :text => "root :text => \"This is the Default Scene scene.\""
   end
   
-  directions :text => "The text attribute tells the prop root to display the text you see on the screen.  To make our spec pass simple change it to this:"
+  directions :text => "The text attribute tells the prop root to display the text you see on the screen.  To make our spec pass simply change it to this:"
   codeblock do
     code :text => "root :text => \"Click Me!\""
   end

--- a/production/documentation/entrances/slideshow/getting_started.rb
+++ b/production/documentation/entrances/slideshow/getting_started.rb
@@ -179,12 +179,16 @@ slide do
   heading :text => "10. A Pretty Prop"
   directions :text => "Okay you've made the scene interactive - now let's make that a little more interesting.  Props can have styles, and we can go ahead and use those to make a prettier prop.  Open your props.rb file again and make it look like this:"
   codeblock do
-    code :text => "root :text => \"Click Me!\"," 
-    code :text => "     :rounded_corner_radius => 10, :padding => 10,"
-    code :text => "     :background_color => '#fffa',"
-    code :text => "     :secondary_background_color => '#fff6',"
-    code :text => "     :gradient => :on, :gradient_angle => 270,"
-    code :text => "     :font_size => 28," 
+    # ------------------------------------------------------------------------------------------------------------------
+    # This does not display properly in the slide.  Specifically, the commas separating the hash values do consistently
+    # appear.  Placing an apostrophe after each undisplayed comma causes it to be displayed properly.
+    # ------------------------------------------------------------------------------------------------------------------
+    code :text => "root :text => \"Click Me!\",'" 
+    code :text => "     :rounded_corner_radius => 10, :padding => 10,'"
+    code :text => "     :background_color => '#fffa','"
+    code :text => "     :secondary_background_color => '#fff6','"
+    code :text => "     :gradient => :on, :gradient_angle => 270,'"
+    code :text => "     :font_size => 28,'" 
     code :text => "     :on_mouse_clicked => \"self.text = 'Hello Limelight!'\""
   end
   

--- a/production/documentation/entrances/slideshow/insets.rb
+++ b/production/documentation/entrances/slideshow/insets.rb
@@ -70,7 +70,7 @@ slide do
     code :text => "padding, top_padding, bottom_padding, left_padding, right_padding"
   end
   
-  directions :text => "Margi Options"
+  directions :text => "Margin Options"
   codeblock do
     code :text => "margin, margin_padding, margin_padding, margin_padding, margin_padding"
   end

--- a/production/documentation/entrances/slideshow/players_built_in.rb
+++ b/production/documentation/entrances/slideshow/players_built_in.rb
@@ -18,7 +18,14 @@ slide do
   codeblock do
     code :text => "built_in_player :text => 'Hello!'"
   end
-  
+  directions :text => "For example, 'text_box' is a built-in Prop.  This is the correct way to create one called 'my_text_box':"
+  line_break
+  codeblock do
+    # -------------------------------------------------------------------------------------
+    # -- the extra apostrophe at the end is needed to get the code to display correctly --
+    # -------------------------------------------------------------------------------------
+    code :text => "my_text_box :players => 'text_box', :text => 'Hello!''"
+  end
 end
 
 slide do
@@ -48,26 +55,33 @@ slide do
   heading :text => "Multiple Players"
   directions :text => "Before we continue with more text events, let's go more in depth with multiple Players.  You've seen how to add multiple Players to a single Prop, but what does that do for us?  When you have multiple Players on a Prop, any events taken on this Prop will call the methods for those events on all the Players on the Prop, not just one of them."
   line_break
-  directions :text => "Here we have a prop with players PlayerOne and PlayerTwo.  When this prop is clicked, the mouse_clicked will be called on both of those modules."
+  directions :text => "Here we have a prop with players PlayerOne and PlayerTwo.  When this prop is clicked, the mouse_clicked event will be called on both of those modules."
   codeblock do
-    code :text => "label :text => 'Hello', :players => 'player_one, player_two'"
+    # -------------------------------------------------------------------------------------
+    # -- the extra apostrophe at the end is needed to get the code to display correctly --
+    # -------------------------------------------------------------------------------------
+    code :text => "label :text => 'Hello', :players => 'player_one, player_two''"
   end
   
 end
 
 slide do
   heading :text => "Custom Text Events"
-  directions :text => "We can use the idea of multiple Player to add custom events to a built-in Player.  The next examples will do this using the text_area Player. Text input fields can detect key presses and focus changes, and to add behavior when those events occur you add a second Player to the prop as shown on the previous slide."
-  directions :text => "In this example the Text Area below would first mixin the text_area player, then also mixin the Custom Player of your own design.  Any events  In the upcoming steps we'll describe how to implement the needed events."
-  
+  directions :text => "We can use the idea of multiple Player to add custom events to a built-in Player.  The next examples will do this using the text_area Player. Text input fields can detect key presses and focus changes. To add behavior when those events occur, you add a second Player to the prop as shown on the previous slide."
+  line_break
+  directions :text => "In this example the Text Area below would first mixin the text_area player, then also mixin the Custom Player of your own design.  In the upcoming steps we'll describe how to implement the needed events."
+  line_break
   codeblock do
-    code :text => "text_area_prop :players => 'text_area, custom'"
+    # -------------------------------------------------------------------------------------
+    # -- the extra apostrophe at the end is needed to get the code to display correctly --
+    # -------------------------------------------------------------------------------------
+    code :text => "text_area_prop :players => 'text_area, custom''"
   end
 end
 
 slide do
   heading :text => "Key Presses"
-  directions :text =>  "Key presses are detected by any of the built-in Players, and can be handled by your Custom Player.  Ditto key releases and key types.  The event in the key press will contain the key....pressed.  What you thought it was hard?  Applying the code below to the Prop on the screen will allow you to count key presses and releases."
+  directions :text =>  "Key presses are detected by any of the built-in Players, and can be handled by your Custom Player.  The same is true for key releases and key types.  The event in the key press will contain the key that was pressed.  What, you thought it was hard?  Applying the code below to the Prop on the screen will allow you to count key presses and releases."
   
   sandbox_codeblock do
     code :text => "def key_pressed(event)"
@@ -87,7 +101,7 @@ end
 
 slide do
   heading :text => "Focus"
-  directions :text => "The focus of the control can also be dectected.  When focus is gained or lost an event is sent.  Let's use the focus change to change the color of a Prop.  When the focus leaves the text area on the left the Prop will turn blue, when it is gained it will turn red."
+  directions :text => "The focus of the control can also be dectected.  When focus is gained or lost an event is sent.  Let's use the focus change to change the color of a Prop.  When the focus leaves the text area on the left the Prop will turn blue, when focus is regained it will turn red."
   
   sandbox_codeblock do
     code :text => "def focus_gained(event)"
@@ -107,7 +121,7 @@ end
 
 slide do
   heading :text => "Buttons"
-  directions :text => "We're done with the text_area Player, and now it's time to move on to a few more built-in Players.  There are three variations on the same thing that we will discuss next: the Button, the Checkbox and the Radio Button.  These work as you might expect, with the Checkbox and Radio Buttons having extra attributes in order to create them.  The two props on the scene here are a Checkbox that is checked, and a traditional button."
+  directions :text => "We're done with the text_area Player and now it's time to move on to a few more built-in Players.  There are three variations on the same theme that we will discuss next: the Button, the Checkbox and the Radio Button.  These work as you might expect, with the Checkbox and Radio Buttons having extra attributes in order to create them.  The two props on the scene here are a Checkbox that is checked, and a traditional button."
   
   sandbox_codeblock do
      code :text => "button_prop :players => 'button', :text => 'button'"
@@ -119,8 +133,9 @@ end
 
 slide do
   heading :text => "Radio Button"
-  directions :text => "The Radio Button requires a small amount of explanation.  Radio Buttons need to be grouped by a group name in order to properly select and unselect the buttons. This is done with the group attribute."
-    
+  directions :text => "The Radio Button requires a small amount of explanation.  Only one radio button in any group can be selected at one time.  Radio Buttons are grouped by assigning the same group name to the group attribute."
+  line_break
+  directions :text => "After running the code below, change the group name of one of the buttons and observe the resulting behavior."
   sandbox_codeblock do
      code :text => "radio_button_prop :players => 'radio_button',"
      code :text => "                  :group => 'button_group'"
@@ -148,14 +163,18 @@ slide do
 end
 
 slide do
+  # ------------------
+  # -- this crashes --
+  # ------------------
   heading :text => "Combo Box Player"
-  directions :text => "The last built-in Player is the Combo Box.  The Combo Box is setup with an array of possible choices, and the current value.  Don't you wish HTML was this simple?"
+  directions :text => "The last built-in Player is the Combo Box.  The Combo Box is setup with an array of possible choices and the current value.  Don't you wish HTML was this simple?"
   
   sandbox_codeblock do
-    code :text => "combo_box_prop :players => 'combo_box', :choices => ['red', 'blue', 'green', 'black'], :value => 'black'"
+    code :text => "combo_box_prop :players => 'combo_box', :choices => ['blue', 'red', 'green', 'black'], :value => 'black'"
   end
   
   __install "documentation/common/prop_sandbox.rb"
+  #__install "documentation/common/players_sandbox.rb", :prop_file => "documentation/entrances/player_examples/combo_box_props.rb", :text_area_height => 100
 end
 
 slide do

--- a/production/documentation/entrances/slideshow/players_built_in.rb
+++ b/production/documentation/entrances/slideshow/players_built_in.rb
@@ -135,7 +135,7 @@ end
 
 slide do
   heading :text => "Button Pressed Event"
-  directions :text => "These new Players introduce a new event - the button press.  This can be implemented to respond to a button press in all the ways you might expect.  The props below are setup with a button and a Prop, ith this code you can make that Prop turn red."
+  directions :text => "These new Players introduce a new event - the button press.  This can be implemented to respond to a button press in all the ways you might expect.  The props below are setup with a button and a Prop, with this code you can make that Prop turn red."
  
   sandbox_codeblock do
     code :text => "def button_pressed(event)"

--- a/production/documentation/entrances/slideshow/players_intro.rb
+++ b/production/documentation/entrances/slideshow/players_intro.rb
@@ -25,7 +25,7 @@ end
 
 slide do
   heading :text => "Player File"
-  directions :text => "Each Scene has a \"players\" directory, which contains a Ruby module for each Player in that scene.  When the Scene is loaded it will attach the the Players to the Props in the Scene."
+  directions :text => "Each Scene has a \"players\" directory, which contains a Ruby module for each Player in that scene.  When the Scene is loaded it will attach the Players to the Props in the Scene."
   line_break
   directions :text => "In addition there can be Production level Players.  Those are created by creating a players directory in the root directory of the Production and putting Players in it.  Production level Players will be available to all Scenes in the Production."
   line_break
@@ -36,7 +36,7 @@ end
 
 slide do
   heading :text => "Players Attribute"
-  directions :text => "Sometimes its inappropriate to name the Prop and the Player the same thing, or perhaps you want to mix-in more than one Player.  This can be done through the players attribute which is used just like the styles attribute.  In the example below you we define this_prop with the Props DSL and assign it the Players NextButton and HighlightedButton."
+  directions :text => "Sometimes its inappropriate to name the Prop and the Player the same thing, or perhaps you want to mix-in more than one Player.  This can be done through the players attribute which is used just like the styles attribute.  In the example below we define this_prop with the Props DSL and assign it the Players NextButton and HighlightedButton."
   
   codeblock do
     code :text => "this_prop :players => 'NextButton, HighlightedButton', :text => 'I am text'"

--- a/production/documentation/entrances/slideshow/prop_partials.rb
+++ b/production/documentation/entrances/slideshow/prop_partials.rb
@@ -24,7 +24,7 @@ end
 
 slide do
   heading :text => "Instance Variables"
-  directions :text => "When loading a Prop Partial, you can also pass in instance variables.  Let's try that out now.  Here is the already creatd Partial:"
+  directions :text => "When loading a Prop Partial, you can also pass in instance variables.  Let's try that out now.  Here is the already created Partial:"
   
   codeblock do
     code :text => "example_partial do"

--- a/production/documentation/entrances/slideshow/text.rb
+++ b/production/documentation/entrances/slideshow/text.rb
@@ -17,7 +17,7 @@ end
 
 slide do
   heading :text => "Font Size"
-  directions :text => "Now that was pretty boring.  Let's try something a little more compliated, like changing the font size.  Let's make it bigger!"
+  directions :text => "Now that was pretty boring.  Let's try something a little more complicated, like changing the font size.  Let's make it bigger!"
   line_break
   line_break
   sandbox_codeblock do


### PR DESCRIPTION
Micah, per our earlier discussion this week, I forked the limelight_docs and have made some changes.  I don't know if you really want to spend time reviewing changes to documentation of an old version of Limelight, but this process has been helpful to me to familiarize myself with Limelight.  (If you recall, I had to install Limelight -v 0.5.5 to get this to work.)

If you think you may want to accept my proposed changes, I thought I would point a few things out to you to minimize your effort.  (If not, just let me know that the documentation is too old to worry about.)  First, about 1/2 of the proposed commits are corrections of typos only.  I tried to segregate the changes in my commits between typos only, and other more significant changes.  There are a couple of proposed commits that I thought you would want to look at more closely:

(1) commit 0819c - "added step 3a ..."

This proposed change adds a new step (numbered 3a) to the getting_started.rb file.  It instructs the user to install an old version of RSpec.  Obviously, if they don't, then the rspec tests in getting_started.rb will fail and the user may not find the reason in the Google Groups email list like I did.

(2) commit d39bc - "correct display of code ..."

When going through the documentation I noticed that the code displayed in the code blocks is often "cut off", or otherwise does not display correctly.  I first ran into this on step 12 of getting_started.rb.  Several of the commas in the hash did not display.  With a little tinkering I discovered that if I inserted apostrophes after each undisplayed comma, it would be correctly displayed.  (I tried changing padding, margins, etc and could not find any solution along those lines.)  That is the correction that I made in this commit.  

I have since discovered that there are other display issues.  For example, often parentheses fail to display properly in the code blocks.  I do not know if this is a problem with my setup or if it is a problem with Limelight.  

(3) commit 50901 - "changed value of width parameter ..."

This was not really an error in the code.  The code was demonstrating the :center style.  It set the width = 200, but the apparent display area was considerably larger than that.  Thus, when the text was centered it looked like it was merely indented and not centered.  That annoyed me.

(4) commit b8067 - "correct typos and rephrase ..."

I made a number of changes to the "directions" given to the user in players_built_in.rb in the hope that they would be somewhat more clear.  Those "editorial" changes are in this commit.
# 

NOTE:  I next came to the combo_box section of players_built_in.rb.  As you may already know, the combo_box crashes the program.  I tinkered with it for a while and was unable to find the cause or a fix.  As I mentioned above, since this is documentation for an old version of Limelight, I am not sure you want to spend the time to fix this problem with the combo_box, but it would be nice if that could be fixed.  (And, of course, it could be a problem with my setup and not Limelight.)

Let me know if you think any of this is useful.

RAB
